### PR TITLE
add slack_id to users table

### DIFF
--- a/app/Http/Controllers/Auth/SlackLoginController.php
+++ b/app/Http/Controllers/Auth/SlackLoginController.php
@@ -34,6 +34,7 @@ class SlackLoginController extends Controller
         $user = User::firstOrCreate([
             'name' => $slackUser->getName(),
             'email' => $slackUser->getEmail(),
+        ],[
             'password' => bcrypt(str_random(16)),
         ]);
 

--- a/app/Http/Controllers/Auth/SlackLoginController.php
+++ b/app/Http/Controllers/Auth/SlackLoginController.php
@@ -31,10 +31,11 @@ class SlackLoginController extends Controller
 
         Log::debug("{$slackUser->getName()} logged in with Slack");
 
-        $user = User::firstOrCreate([
+        $user = User::updateOrCreate([
+            'slack_id' => $slackUser->getId()
+        ],[
             'name' => $slackUser->getName(),
             'email' => $slackUser->getEmail(),
-        ],[
             'password' => bcrypt(str_random(16)),
         ]);
 

--- a/database/migrations/2018_02_03_154644_add_slack_id_to_user_table.php
+++ b/database/migrations/2018_02_03_154644_add_slack_id_to_user_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSlackIdToUserTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('slack_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::hasColumn('users', 'slack_id')) {
+
+            Schema::table('users', function (Blueprint $table) {
+                $table->dropColumn('slack_id');
+            });
+
+        }
+    }
+}


### PR DESCRIPTION
Improve Slack sign in integration by storing the user's Slack ID in the DB when logging in