### PR TITLE
improve Slack signin process

### DIFF
--- a/app/Http/Controllers/Auth/SlackLoginController.php
+++ b/app/Http/Controllers/Auth/SlackLoginController.php
@@ -11,7 +11,7 @@ use App\Http\Controllers\Controller;
 class SlackLoginController extends Controller
 {
     /**
-     * Redirect the user to the GitHub authentication page.
+     * Redirect the user to the Slack authentication page.
      *
      * @return \Illuminate\Http\Response
      */
@@ -21,7 +21,7 @@ class SlackLoginController extends Controller
     }
 
     /**
-     * Obtain the user information from slack.
+     * Obtain the user information from Slack.
      *
      * @return \Illuminate\Http\Response
      */

--- a/app/Http/Controllers/Auth/SlackLoginController.php
+++ b/app/Http/Controllers/Auth/SlackLoginController.php
@@ -29,7 +29,7 @@ class SlackLoginController extends Controller
     {
         $slackUser = Socialite::driver('slack')->user();
 
-        Log::debug("{$slackUser->getName()} logged in with Slack");
+        Log::debug("{$slackUser->getName()} ({$slackUser->getId()}) logged in with Slack");
 
         $user = User::updateOrCreate([
             'slack_id' => $slackUser->getId()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,7 +16,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'location', 'password',
+        'name', 'email', 'location', 'password', 'slack_id'
     ];
 
     /**


### PR DESCRIPTION
I initially handled login and register through Laravel's _updateOrCreate_ method, but I think separating login and register into two methods makes for better readability, and allows us to add different events when registering vs signing in.