### PR TITLE
Fix broken avatar on comments

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -96,7 +96,7 @@ class User extends Authenticatable
 
     public function getAvatarAttribute($avatar)
     {
-        if (is_null($avatar)) {
+        if (is_null($avatar) || empty($avatar)) {
             return asset('/images/default-avatar.png');
         } else {
             return $avatar;


### PR DESCRIPTION
Avatar broken if the column in the users table was empty. Now returns default avatar if null or empty