### PR TITLE
Limit tag creation to Administrators

### DIFF
--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -61,16 +61,13 @@ class PostController extends Controller
         $post->user_id = auth()->id();
         $post->save();
 
-        // Only Store tags if they have been passed through
-        if ($request->data['tags']) {
-            $post->tag($request->data['tags']);
+        // Only allow administrators to save tags.
+        if (auth()->user()->hasRole(config('laraveluk.admin_role_name'))) {
+            // Only Store tags if they have been passed through
+            if ($request->data['tags']) {
+                $post->tag($request->data['tags']);
+            }
         }
-
-        // $tags = explode(',', $request->data['tags']);
-        // $tags = array_filter($tags);
-        // foreach ($tags as $tag) {
-        //     $post->attachTag(trim($tag));
-        // }
 
         if (auth()->user()) {
             Log::debug(auth()->user()->name . " created post {$post->id}");

--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -62,7 +62,7 @@ class PostController extends Controller
         $post->save();
 
         // Only allow administrators to save tags.
-        if (auth()->user()->hasRole(config('laraveluk.admin_role_name'))) {
+        if (auth()->user()->hasRole(config('laraveluk.site.admin_role_name'))) {
             // Only Store tags if they have been passed through
             if ($request->data['tags']) {
                 $post->tag($request->data['tags']);

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -7,7 +7,12 @@ use Illuminate\Database\Eloquent\Model;
 class Role extends Model
 {
     public $timestamps = false;
-    
+
+    /**
+     * A Role belongs to many Users
+     * 
+     * @return Illuminate\Database\Eloquent\Relations\BelongsToMangy
+     */
     public function users()
     {
         return $this->belongsToMany(User::class);

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Role extends Model
 {
+    public $timestamps = false;
+    
     public function users()
     {
         return $this->belongsToMany(User::class);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -84,7 +84,7 @@ class User extends Authenticatable
     /**
      * Assign user to role
      *
-     * @param $role
+     * @param App\Models\Role $role
      */
     public function assignRole(Role $role)
     {
@@ -94,7 +94,7 @@ class User extends Authenticatable
     /**
      * Remove user role
      *
-     * @param $role
+     * @param App\Models\Role $role
      * @return int
      */
     public function removeRole($role)
@@ -102,6 +102,12 @@ class User extends Authenticatable
         return $this->roles()->detach($role);
     }
 
+    /**
+     * Get the avatar attribute
+     * 
+     * @param string $avatar
+     * @return string
+     */
     public function getAvatarAttribute($avatar)
     {
         if (is_null($avatar) || empty($avatar)) {
@@ -111,10 +117,14 @@ class User extends Authenticatable
         }
     }
 
-    public function attemptSlackNotification() {
-
+    /**
+     * Attempt the slack notification email
+     * 
+     * @return Unirest\Request
+     */
+    public function attemptSlackNotification() 
+    {
         $token = config('slack.legacy_token');
         \Unirest\Request::post(config('slack.invitation_url'), [], ['token' => $token, 'email' => $this->email]);
-
     }
 }

--- a/config/laraveluk.php
+++ b/config/laraveluk.php
@@ -7,7 +7,8 @@ return [
                 'name' => 'Laravel UK',
                 'url' => 'https://laravelphp.uk',
                 'description' => 'Welcome to the new LaravelUK website and thanks for taking a look.',
-                'keywords' => 'laravel, larvel UK, UK Laravel, UK, php, framework, web, artisans'
+                'keywords' => 'laravel, larvel UK, UK Laravel, UK, php, framework, web, artisans',
+                'admin_role_name' => 'Administrator'g
         ],
         'social' => [
                 'twitter_url' => 'https://twitter.com/UKLaravel',

--- a/config/laraveluk.php
+++ b/config/laraveluk.php
@@ -8,7 +8,7 @@ return [
                 'url' => 'https://laravelphp.uk',
                 'description' => 'Welcome to the new LaravelUK website and thanks for taking a look.',
                 'keywords' => 'laravel, larvel UK, UK Laravel, UK, php, framework, web, artisans',
-                'admin_role_name' => 'Administrator'g
+                'admin_role_name' => 'Administrator'
         ],
         'social' => [
                 'twitter_url' => 'https://twitter.com/UKLaravel',

--- a/database/factories/RoleFactory.php
+++ b/database/factories/RoleFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+use Faker\Generator as Faker;
+
+$factory->define(App\Models\Role::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name
+    ];
+});

--- a/database/seeds/RoleSeeder.php
+++ b/database/seeds/RoleSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(App\Models\Role::class)->create([
+            'name' => 'Administrator',
+        ]);
+        
+        factory(App\Models\Role::class)->create([
+            'name' => 'Member',
+        ]);
+    }
+}

--- a/resources/assets/js/backend/app/blog/components/PostCreate.vue
+++ b/resources/assets/js/backend/app/blog/components/PostCreate.vue
@@ -29,7 +29,7 @@
                         <vue-editor v-model="post.body"></vue-editor>  
                     </div>
 
-                    <div class="mb-4">
+                    <div class="mb-4" v-if="isAdmin">
                         <label for="title">Tags <sup>optional</sup></label>
                         <p class="info">Please separate tags with a comma.</p>
                         <input class="" v-model="post.tags">
@@ -56,8 +56,9 @@ export default {
         title: "",
         body: "",
         post_type: "post",
-        tags: ""
-      }
+        tags: "",
+      },
+      isAdmin: window.App.is_admin
     };
   },
 

--- a/resources/views/backend/master.blade.php
+++ b/resources/views/backend/master.blade.php
@@ -18,7 +18,8 @@
         window.App = {!!
             json_encode([
                 'signedIn' => auth()->check(),
-                'user'     => auth()->user()
+                'user'     => auth()->user(),
+                'is_admin'     => auth()->user()->hasRole(config('laraveluk.site.admin_role_name'))
             ]);
         !!}
     </script>

--- a/resources/views/frontend/master.blade.php
+++ b/resources/views/frontend/master.blade.php
@@ -6,7 +6,7 @@
         window.App = {!!
             json_encode([
                 'signedIn' => auth()->check(),
-                'user'     => auth()->user()
+                'user'     => auth()->user(),
             ]);
         !!}
     </script>


### PR DESCRIPTION
Using the Role system which was in place, I've added a configuration variable in `config/laraveluk.php` to define the site administrator role name, and then I check if the user has that Role when creating tags in the backend.

On the front end, I have added an `is_admin` property to the `window.App` object defined in `backend/master.blade.php` and I use this in `PostCreate.vue` to determine whether or not to display the tag creation input.

The Role system did not have a Seeder or a Factory so those have been added as a part of this work. Should address #85 nicely.